### PR TITLE
use relative not absolute path in j-toker script tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,7 +230,7 @@
       <script src='./js/vendor/devise_token_auth/pubsub.js'></script>
 
       <!-- this should come AFTER the preceeding files -->
-      <script src='/js/vendor/devise_token_auth/j-toker.js'></script>
+      <script src='./js/vendor/devise_token_auth/j-toker.js'></script>
       <!-- jToker will now be available at $.auth -->
 
       <script src="./js/vendor/bootstrap/bootstrap.min.js"></script>


### PR DESCRIPTION
eyyy 

was setting up dreamcacher on my machine and console was throwing error bc `$.auth` was `undefined`

looked in `index.html` and switched j-toker `<script>`'s `src` from an absolute path to a relative path. things seem to work for me now  
