### PR TITLE
highlighted sphere instantiation.

### DIFF
--- a/js/app/environment.js
+++ b/js/app/environment.js
@@ -25,7 +25,6 @@ environment.initializeFlyControls = function () {
   this.controls.rollSpeed = Math.PI / 1600;
   this.controls.autoForward = false;
   this.controls.dragToLook = false;
-
 }
 
 environment.initializeRenderer = function () {

--- a/js/app/environment.js
+++ b/js/app/environment.js
@@ -21,12 +21,10 @@ var environment = {
 
 environment.initializeFlyControls = function () {
   this.controls = new THREE.FlyControls(this.camera, this.container)
-  this.controls.domElement = document.getElementById('asdf')
   this.controls.movementSpeed = 1;
   this.controls.rollSpeed = Math.PI / 1600;
   this.controls.autoForward = false;
   this.controls.dragToLook = false;
-  console.log(this.controls.mousedown)
 
 }
 

--- a/js/app/environment.js
+++ b/js/app/environment.js
@@ -21,10 +21,13 @@ var environment = {
 
 environment.initializeFlyControls = function () {
   this.controls = new THREE.FlyControls(this.camera, this.container)
+  this.controls.domElement = document.getElementById('asdf')
   this.controls.movementSpeed = 1;
   this.controls.rollSpeed = Math.PI / 1600;
   this.controls.autoForward = false;
   this.controls.dragToLook = false;
+  console.log(this.controls.mousedown)
+
 }
 
 environment.initializeRenderer = function () {
@@ -50,6 +53,18 @@ environment.initializePickingScene = function () {
   this.pickingTexture.minFilter = THREE.LinearFilter;
   this.pickingTexture.generateMipmaps = false;
   this.pickingMaterial = new THREE.MeshBasicMaterial( { vertexColors: THREE.VertexColors } )
+}
+
+environment.initHighlightSphere = function () {
+  var geometry = new THREE.SphereGeometry( 5, 32, 32 )
+  var material = new THREE.MeshBasicMaterial({
+    color: 0xeeeeee,
+    side: THREE.BackSide,
+    transparent: true,
+    opacity: 0.5
+  })
+  this.highlightSphere = new THREE.Mesh( geometry, material )
+  this.addObjectToScene( this.highlightSphere );
 }
 
 // update fxns
@@ -157,6 +172,7 @@ environment.init = function () {
   this.initializeRenderer()
   this.initializePickingScene()
   this.initializeWindowResize()
+  this.initHighlightSphere()
   this.onRenderFcts = [
     this.updateMarbleTexture.bind(this),
     this.updateControls.bind(this),

--- a/js/app/view.js
+++ b/js/app/view.js
@@ -92,18 +92,6 @@ var dreamsView = {
     environment.pickingMesh = new THREE.Mesh( pickingGeometry, environment.pickingMaterial )
     environment.pickingScene.add( environment.pickingMesh );
 
-    environment.highlightSphere = new THREE.Mesh(
-      new THREE.SphereGeometry( 5, 32, 32 ),
-      new THREE.MeshBasicMaterial({
-        color: 0xeeeeee,
-        side: THREE.BackSide,
-        transparent: true,
-        opacity: 0.5
-      })
-    )
-
-    environment.addObjectToScene( environment.highlightSphere );
-
     environment.resetCameraPosition()
 
   },


### PR DESCRIPTION
moved highlightSphere instantiation from dreamsView.populateDreamscape() into an environment.init fxn.

HighlightSphere WAS getting instantiated every time the dreamscape was being populated.
In fact, we only need to instantiate highlightSphere at the beginning of the user experience. After that it just gets shown and hidden.

This pr reflects that, and now highlightSphere only gets initiated once, when environment.init() is run.
