### PR TITLE
Feature/dreams change color after being read

### DIFF
--- a/js/app/controller.js
+++ b/js/app/controller.js
@@ -5,7 +5,6 @@ var $ = require('jquery')
 var dreamsModel = require('./model.js')
 var dreamsView = require('./view.js')
 var queryString = require('query-string')
-var range = require('lodash.range')
 
 var controller = {
   init: function () {
@@ -118,25 +117,13 @@ var controller = {
     // three.js stuff
 
     environment.renderer.domElement.addEventListener('mousedown', function () {
-      if (environment.objectUnderMouse >= 0) {
+      var dreamIndex = environment.objectUnderMouse
+      if (dreamIndex >= 0) {
         // make the modal appear with the correct dream data
-        var dream = dreamsModel.dreamData[environment.objectUnderMouse]
+        var dream = dreamsModel.dreamData[dreamIndex]
         if (dream) {
           dreamsModel.getTagsForDream(dream)
-
-          var clonedGeom = environment.dreamsMesh.geometry.clone()
-          environment.removeObjectFromScene(environment.dreamsMesh)
-
-          var faceIndices = environment.pickingData[environment.objectUnderMouse].faceIndices
-
-          range(faceIndices.low, faceIndices.hi).forEach(function (faceIndex) {
-            clonedGeom.faces[faceIndex].materialIndex = 1
-          })
-
-          var materials = [ environment.defaultMaterial, environment.viewedMaterial ]
-
-          environment.dreamsMesh = new THREE.Mesh( clonedGeom, new THREE.MultiMaterial(materials) )
-          environment.addObjectToScene( environment.dreamsMesh )
+          environment.markDreamAsViewed(dreamIndex)
         }
       }
     })

--- a/js/app/controller.js
+++ b/js/app/controller.js
@@ -136,8 +136,7 @@ var controller = {
 
           environment.allDreamsGeometry = clonedGeom
 
-          var viewedMaterial = new THREE.MeshBasicMaterial({shading: THREE.FlatShading, color: 0x00f0ff})
-          var materials = [ environment.defaultMaterial, viewedMaterial ]
+          var materials = [ environment.defaultMaterial, environment.viewedMaterial ]
 
           environment.dreamsMesh = new THREE.Mesh( clonedGeom, new THREE.MultiMaterial(materials) );
           environment.addObjectToScene( environment.dreamsMesh );

--- a/js/app/controller.js
+++ b/js/app/controller.js
@@ -5,6 +5,7 @@ var $ = require('jquery')
 var dreamsModel = require('./model.js')
 var dreamsView = require('./view.js')
 var queryString = require('query-string')
+var range = require('lodash.range')
 
 var controller = {
   init: function () {
@@ -126,22 +127,17 @@ var controller = {
           var clonedGeom = environment.dreamsMesh.geometry.clone()
           environment.removeObjectFromScene(environment.dreamsMesh)
 
-          var facesLocation = environment.pickingData[environment.objectUnderMouse].facesLocation
-          var facesLow = facesLocation.low
-          var facesHi = facesLocation.hi
+          var faceIndices = environment.pickingData[environment.objectUnderMouse].faceIndices
 
-          for (var i = facesLow; i <= facesHi; i++) {
-            clonedGeom.faces[i].materialIndex = 1
-          };
+          range(faceIndices.low, faceIndices.hi).forEach(function (faceIndex) {
+            clonedGeom.faces[faceIndex].materialIndex = 1
+          })
 
           var materials = [ environment.defaultMaterial, environment.viewedMaterial ]
 
-          environment.dreamsMesh = new THREE.Mesh( clonedGeom, new THREE.MultiMaterial(materials) );
-          environment.addObjectToScene( environment.dreamsMesh );
+          environment.dreamsMesh = new THREE.Mesh( clonedGeom, new THREE.MultiMaterial(materials) )
+          environment.addObjectToScene( environment.dreamsMesh )
         }
-
-
-
       }
     })
 

--- a/js/app/controller.js
+++ b/js/app/controller.js
@@ -1,3 +1,4 @@
+var THREE = require('three')
 var Auth = global.Auth
 var environment = global.environment
 var $ = require('jquery')
@@ -119,7 +120,32 @@ var controller = {
       if (environment.objectUnderMouse >= 0) {
         // make the modal appear with the correct dream data
         var dream = dreamsModel.dreamData[environment.objectUnderMouse]
-        if (dream) { dreamsModel.getTagsForDream(dream) }
+        // if (dream) { dreamsModel.getTagsForDream(dream) }
+
+
+        environment.removeObjectFromScene(environment.dreamsMesh)
+        var clonedGeom = environment.allDreamsGeometry.clone()
+
+        var facesLocation = environment.pickingData[environment.objectUnderMouse].facesLocation
+        var facesLow = facesLocation.low
+        var facesHi = facesLocation.hi
+
+        for (var i = facesLow; i <= facesHi; i++) {
+          clonedGeom.faces[i].materialIndex = 1
+        };
+
+        environment.allDreamsGeometry = clonedGeom
+
+        var seenMaterial = new THREE.MeshBasicMaterial({shading: THREE.FlatShading, color: 0x00f0ff})
+        var materials = [ environment.defaultMaterial, seenMaterial ]
+        console.log(materials)
+
+        environment.dreamsMesh = new THREE.Mesh( clonedGeom, new THREE.MultiMaterial(materials) );
+        environment.addObjectToScene( environment.dreamsMesh );
+
+
+
+
       }
     })
 

--- a/js/app/controller.js
+++ b/js/app/controller.js
@@ -15,7 +15,7 @@ var controller = {
     }).fail(function () {
       dreamsView.setNavBarSignedOut()
     })
-    dreamsModel.getDreams()
+    dreamsModel.getDreams('all')
   },
   bindEventListeners: function () {
     // change dream collections
@@ -23,14 +23,14 @@ var controller = {
       e.preventDefault()
       $(this).addClass('active')
       $('#my-dreams-tab').removeClass('active')
-      dreamsModel.getDreams()
+      dreamsModel.getDreams('all')
     })
 
     $('#my-dreams-tab').on('click', function(e) {
       e.preventDefault()
       $(this).addClass('active')
       $('#dreamscape-tab').removeClass('active')
-      dreamsModel.getDreams()
+      dreamsModel.getDreams('forUser')
     })
 
     // new dreams
@@ -79,7 +79,7 @@ var controller = {
       e.preventDefault()
       Auth.signOut()
       dreamsView.setNavBarSignedOut()
-      dreamsModel.getDreams()
+      dreamsModel.getDreams('all')
     })
 
     // create new account modal
@@ -132,7 +132,7 @@ var controller = {
       e.preventDefault()
       var tag = this.id
       $('#dreamReadModal').modal('hide');
-      dreamsModel.getDreamsForTag(tag)
+      dreamsModel.getDreams({tag: tag})
       $('#dreamscape-tab').removeClass('active')
       $('#my-dreams-tab').removeClass('active')
     })

--- a/js/app/controller.js
+++ b/js/app/controller.js
@@ -10,12 +10,12 @@ var controller = {
   init: function () {
     environment.init()
     environment.render()
-    dreamsModel.getDreams()
     Auth.validateToken().then(function () {
       dreamsView.setNavBarSignedIn()
     }).fail(function () {
       dreamsView.setNavBarSignedOut()
     })
+    dreamsModel.getDreams()
   },
   bindEventListeners: function () {
     // change dream collections

--- a/js/app/controller.js
+++ b/js/app/controller.js
@@ -123,8 +123,8 @@ var controller = {
         if (dream) {
           dreamsModel.getTagsForDream(dream)
 
+          var clonedGeom = environment.dreamsMesh.geometry.clone()
           environment.removeObjectFromScene(environment.dreamsMesh)
-          var clonedGeom = environment.allDreamsGeometry.clone()
 
           var facesLocation = environment.pickingData[environment.objectUnderMouse].facesLocation
           var facesLow = facesLocation.low
@@ -133,8 +133,6 @@ var controller = {
           for (var i = facesLow; i <= facesHi; i++) {
             clonedGeom.faces[i].materialIndex = 1
           };
-
-          environment.allDreamsGeometry = clonedGeom
 
           var materials = [ environment.defaultMaterial, environment.viewedMaterial ]
 

--- a/js/app/controller.js
+++ b/js/app/controller.js
@@ -120,29 +120,28 @@ var controller = {
       if (environment.objectUnderMouse >= 0) {
         // make the modal appear with the correct dream data
         var dream = dreamsModel.dreamData[environment.objectUnderMouse]
-        // if (dream) { dreamsModel.getTagsForDream(dream) }
+        if (dream) {
+          dreamsModel.getTagsForDream(dream)
 
+          environment.removeObjectFromScene(environment.dreamsMesh)
+          var clonedGeom = environment.allDreamsGeometry.clone()
 
-        environment.removeObjectFromScene(environment.dreamsMesh)
-        var clonedGeom = environment.allDreamsGeometry.clone()
+          var facesLocation = environment.pickingData[environment.objectUnderMouse].facesLocation
+          var facesLow = facesLocation.low
+          var facesHi = facesLocation.hi
 
-        var facesLocation = environment.pickingData[environment.objectUnderMouse].facesLocation
-        var facesLow = facesLocation.low
-        var facesHi = facesLocation.hi
+          for (var i = facesLow; i <= facesHi; i++) {
+            clonedGeom.faces[i].materialIndex = 1
+          };
 
-        for (var i = facesLow; i <= facesHi; i++) {
-          clonedGeom.faces[i].materialIndex = 1
-        };
+          environment.allDreamsGeometry = clonedGeom
 
-        environment.allDreamsGeometry = clonedGeom
+          var viewedMaterial = new THREE.MeshBasicMaterial({shading: THREE.FlatShading, color: 0x00f0ff})
+          var materials = [ environment.defaultMaterial, viewedMaterial ]
 
-        var seenMaterial = new THREE.MeshBasicMaterial({shading: THREE.FlatShading, color: 0x00f0ff})
-        var materials = [ environment.defaultMaterial, seenMaterial ]
-        console.log(materials)
-
-        environment.dreamsMesh = new THREE.Mesh( clonedGeom, new THREE.MultiMaterial(materials) );
-        environment.addObjectToScene( environment.dreamsMesh );
-
+          environment.dreamsMesh = new THREE.Mesh( clonedGeom, new THREE.MultiMaterial(materials) );
+          environment.addObjectToScene( environment.dreamsMesh );
+        }
 
 
 

--- a/js/app/controller.js
+++ b/js/app/controller.js
@@ -123,7 +123,7 @@ var controller = {
         var dream = dreamsModel.dreamData[dreamIndex]
         if (dream) {
           dreamsModel.getTagsForDream(dream)
-          environment.markDreamAsViewed(dreamIndex)
+          dreamsModel.markDreamAsViewed(dream)
         }
       }
     })

--- a/js/app/controller.js
+++ b/js/app/controller.js
@@ -10,7 +10,7 @@ var controller = {
   init: function () {
     environment.init()
     environment.render()
-    dreamsModel.getAllDreams()
+    dreamsModel.getDreams()
     Auth.validateToken().then(function () {
       dreamsView.setNavBarSignedIn()
     }).fail(function () {
@@ -23,14 +23,14 @@ var controller = {
       e.preventDefault()
       $(this).addClass('active')
       $('#my-dreams-tab').removeClass('active')
-      dreamsModel.getAllDreams()
+      dreamsModel.getDreams()
     })
 
     $('#my-dreams-tab').on('click', function(e) {
       e.preventDefault()
       $(this).addClass('active')
       $('#dreamscape-tab').removeClass('active')
-      dreamsModel.getDreamsForUser()
+      dreamsModel.getDreams()
     })
 
     // new dreams
@@ -78,8 +78,8 @@ var controller = {
     $('#log-out-btn').on('click', function(e) {
       e.preventDefault()
       Auth.signOut()
-      dreamsModel.getAllDreams()
       dreamsView.setNavBarSignedOut()
+      dreamsModel.getDreams()
     })
 
     // create new account modal

--- a/js/app/controller.js
+++ b/js/app/controller.js
@@ -123,7 +123,7 @@ var controller = {
         var dream = dreamsModel.dreamData[dreamIndex]
         if (dream) {
           dreamsModel.getTagsForDream(dream)
-          dreamsModel.markDreamAsViewed(dream)
+          if (!dream.viewed) { dreamsModel.markDreamAsViewed(dream) }
         }
       }
     })

--- a/js/app/environment.js
+++ b/js/app/environment.js
@@ -85,6 +85,7 @@ environment.updatePickingScene = function () {
       this.highlightSphere.scale.copy( data.scale ).add( this.offset )
       this.highlightSphere.visible = true
       this.objectUnderMouse = id
+      // this.verticesLocation = data.verticesLocation
     }
   } else {
     if (this.highlightSphere) { this.highlightSphere.visible = false; }

--- a/js/app/environment.js
+++ b/js/app/environment.js
@@ -2,6 +2,7 @@ var THREE = require('three')
 var NoiseShaderMaterial = require('three-noise-shader-material')(THREE)
 var WindowResize = require('three-window-resize')
 require('three-fly-controls')(THREE)
+var range = require('lodash.range')
 
 var environment = {
   objectUnderMouse: null,
@@ -183,6 +184,19 @@ environment.render = function () {
       onRenderFct(deltaMsec/1000, nowMsec/1000)
     })
   })
+}
+
+environment.markDreamAsViewed = function (dreamIndex) {
+  var clonedGeom = this.dreamsMesh.geometry.clone()
+  this.removeObjectFromScene(this.dreamsMesh)
+  var faceIndices = this.pickingData[dreamIndex].faceIndices
+  range(faceIndices.low, faceIndices.hi).forEach(function (faceIndex) {
+    clonedGeom.faces[faceIndex].materialIndex = 1
+  })
+
+  var materials = [ this.defaultMaterial, this.viewedMaterial ]
+  this.dreamsMesh = new THREE.Mesh( clonedGeom, new THREE.MultiMaterial(materials) )
+  this.addObjectToScene( this.dreamsMesh )
 }
 
 module.exports = environment

--- a/js/app/environment.js
+++ b/js/app/environment.js
@@ -12,6 +12,7 @@ var environment = {
   offset: new THREE.Vector3(10, 10, 10),
   container: document.getElementById('container'),
   defaultMaterial: NoiseShaderMaterial(),
+  viewedMaterial: new THREE.MeshBasicMaterial({shading: THREE.FlatShading, color: 0x00f0ff}),
   camera: new THREE.PerspectiveCamera(80, window.innerWidth / window.innerHeight, 1, 20000),
   scene: new THREE.Scene(),
   renderer: new THREE.WebGLRenderer({ antialias: true})

--- a/js/app/environment.js
+++ b/js/app/environment.js
@@ -86,7 +86,6 @@ environment.updatePickingScene = function () {
       this.highlightSphere.scale.copy( data.scale ).add( this.offset )
       this.highlightSphere.visible = true
       this.objectUnderMouse = id
-      // this.verticesLocation = data.verticesLocation
     }
   } else {
     if (this.highlightSphere) { this.highlightSphere.visible = false; }

--- a/js/app/environment.js
+++ b/js/app/environment.js
@@ -12,7 +12,7 @@ var environment = {
   offset: new THREE.Vector3(10, 10, 10),
   container: document.getElementById('container'),
   defaultMaterial: NoiseShaderMaterial(),
-  viewedMaterial: new THREE.MeshBasicMaterial({shading: THREE.FlatShading, color: 0x00f0ff}),
+  viewedMaterial: new THREE.MeshBasicMaterial({shading: THREE.FlatShading, color: 0x000000}),
   camera: new THREE.PerspectiveCamera(80, window.innerWidth / window.innerHeight, 1, 20000),
   scene: new THREE.Scene(),
   renderer: new THREE.WebGLRenderer({ antialias: true})

--- a/js/app/model.js
+++ b/js/app/model.js
@@ -63,6 +63,15 @@ var dreamsModel =  {
     })
   },
 
+  markDreamAsViewed: function (dream) {
+    Auth.validateToken().then(function () {
+      $.post(global.apiUrl + '/views', {view: {dream_id: dream.id}}).then(function () {
+        dream.viewed = true
+        environment.markDreamAsViewed(dream.objectId)
+      })
+    })
+  },
+
   getTagsForDream: function (dream) {
     var data = {dream_id: dream.id}
     $.ajax({

--- a/js/app/model.js
+++ b/js/app/model.js
@@ -25,9 +25,8 @@ var dreamsModel =  {
     })
   },
 
-  getDreams: function () {
+  getDreams: function (fetchType) {
     var self = this
-    fetchType = $('#my-dreams-tab').hasClass('active') ? 'forUser' : 'all'
     this.fetchDreams(fetchType).then(function () {
       self.fetchViews().then(function () {
         environment.clearScene()
@@ -44,7 +43,8 @@ var dreamsModel =  {
       type: "POST",
       data : formData
     }).then(function () {
-      self.getDreams()
+      fetchType = $('#my-dreams-tab').hasClass('active') ? 'forUser' : 'all'
+      self.getDreams(fetchType)
     }).fail(function (err) {
       console.log('err: ', err)
     })
@@ -72,23 +72,17 @@ var dreamsModel =  {
     })
   },
 
-  getDreamsForTag: function (tag) {
-    var self = this
-    var data = {tag: tag}
-    $.ajax({
-      url: global.apiUrl + "/tag/dreams",
-      type: 'GET',
-      data: data
-    }).then(function (dreams) {
-      self.dreamData = dreams
-      environment.clearScene()
-      dreamsView.populateDreamscape(dreams)
-    }).fail(function (err) {
-      console.log("Error: ", err)
-    })
-  },
-
   // private
+
+  pathForFetchType: function (fetchType) {
+    if (typeof fetchType === 'object' && fetchType.tag) {
+      return '/tag/dreams?tag=' + fetchType.tag
+    } else if (fetchType === 'forUser') {
+      return '/user/dreams'
+    } else {
+      return '/dreams'
+    }
+  },
 
   fetchViews: function () {
     var self = this
@@ -110,7 +104,8 @@ var dreamsModel =  {
   fetchDreams: function (fetchType) {
     var self = this
     var $deferred = $.Deferred()
-    var apiPath = fetchType === 'forUser' ? '/user/dreams' : '/dreams'
+
+    var apiPath = this.pathForFetchType(fetchType)
     $.get(global.apiUrl + apiPath).then(function (dreams) {
       self.dreamData = dreams
       self.dreamData.forEach(function (dream, i) { dream.objectId = i })

--- a/js/app/model.js
+++ b/js/app/model.js
@@ -26,10 +26,17 @@ var dreamsModel =  {
   },
 
   fetchDreams: function (fetchType) {
+    var $deferred = $.Deferred()
     var apiPath = fetchType === 'forUser' ? '/user/dreams' : '/dreams'
-    var $promise = $.get(global.apiUrl + apiPath)
-    $promise.fail(function (err) { console.log('err: ', err) })
-    return $promise
+    $.get(global.apiUrl + apiPath).then(function (dreams) {
+      self.dreamData = dreams
+      self.dreamData.forEach(function (dream, i) { dream.objectId = i })
+      $deferred.resolve(self.dreamData)
+    }).fail(function (err) {
+      console.log('err: ', err)
+      $deferred.reject()
+    })
+    return $deferred.promise()
   },
 
   getDreams: function () {

--- a/js/app/model.js
+++ b/js/app/model.js
@@ -25,41 +25,20 @@ var dreamsModel =  {
     })
   },
 
-  getDreamsForUser: function() {
-    var self = this
-    $.ajax({
-      url: global.apiUrl + "/user/dreams",
-      type: 'GET'
-    }).then(function (dreams) {
-      self.dreamData = dreams
-      environment.clearScene()
-      dreamsView.populateDreamscape(dreams)
-    }).fail(function (err) {
-      console.log("Error: ", err)
-    })
-  },
-
-  getAllDreams: function () {
-    var self = this
-    var returnValue = null
-    $.ajax({
-      url: global.apiUrl + "/dreams",
-      type: 'GET'
-    }).then(function (dreams){
-      self.dreamData = dreams
-      environment.clearScene()
-      dreamsView.populateDreamscape(dreams)
-    }).fail(function (err){
-      console.log("Error: ", err)
-    })
+  fetchDreams: function (fetchType) {
+    var apiPath = fetchType === 'forUser' ? '/user/dreams' : '/dreams'
+    var $promise = $.get(global.apiUrl + apiPath)
+    return $promise
   },
 
   getDreams: function () {
-    if ($('#my-dreams-tab').hasClass('active')) {
-      this.getDreamsForUser()
-    } else {
-      this.getAllDreams()
-    }
+    var self = this
+    fetchType = $('#my-dreams-tab').hasClass('active') ? 'forUser' : 'all'
+    this.fetchDreams(fetchType).then(function (dreams) {
+      self.dreamData = dreams
+      environment.clearScene()
+      dreamsView.populateDreamscape(dreams)
+    })
   },
 
   saveDream: function (dream) {

--- a/js/app/model.js
+++ b/js/app/model.js
@@ -28,6 +28,7 @@ var dreamsModel =  {
   fetchDreams: function (fetchType) {
     var apiPath = fetchType === 'forUser' ? '/user/dreams' : '/dreams'
     var $promise = $.get(global.apiUrl + apiPath)
+    $promise.fail(function (err) { console.log('err: ', err) })
     return $promise
   },
 

--- a/js/app/view.js
+++ b/js/app/view.js
@@ -7,6 +7,7 @@ var moment = require('moment')
 var parseDreamString = require('./../services/parse-dream-string')
 var $ = require('jquery')
 require('bootstrap-jquery')
+var range = require('lodash.range')
 
 // posts stuff to the dom
 var dreamsView = {
@@ -68,22 +69,18 @@ var dreamsView = {
       // the matrix has the position, scale, and rotation of the object
       matrix.compose( matrixData.position, quaternion, matrixData.scale );
 
-      var facesBeforeMerge = allDreamsGeometry.faces.length
+      var faceCountBeforeMerge = allDreamsGeometry.faces.length
       allDreamsGeometry.merge(singleDreamGeom, matrix)
-      var facesAfterMerge = allDreamsGeometry.faces.length
+      var faceCountAfterMerge = allDreamsGeometry.faces.length
 
-      var facesLocation = { // this is how we can find the faces for this particular geom, after it is merged into the single geom
-        low: facesBeforeMerge,
-        hi: facesAfterMerge - 1
+      var faceIndices = { // this is how we can find the faces for this particular geom, after it is merged into the single geom
+        low: faceCountBeforeMerge,
+        hi: faceCountAfterMerge
       }
 
-      var facesLow = facesLocation.low
-      var facesHi = facesLocation.hi
-
-
-      for (var j = facesLow; j <= facesHi; j++) { // this is to support dream.viewed feature yet to be added to the rails back end
-        allDreamsGeometry.faces[j].materialIndex = (dream.viewed) ? 1 : 0
-      };
+      range(faceIndices.low, faceIndices.hi).forEach(function (faceIndex) { // this is to support dream.viewed feature yet to be added to the rails back end
+        allDreamsGeometry.faces[faceIndex].materialIndex = (dream.viewed) ? 1 : 0
+      })
 
       // give the singleDreamGeom's vertices a color corresponding to the "id"
       applyVertexColorsToGeometry( singleDreamGeom, color.setHex( i ) );
@@ -94,7 +91,7 @@ var dreamsView = {
         position: matrixData.position,
         rotation: matrixData.rotation,
         scale: matrixData.scale,
-        facesLocation: facesLocation
+        faceIndices: faceIndices
       }
     })
 

--- a/js/app/view.js
+++ b/js/app/view.js
@@ -56,15 +56,13 @@ var dreamsView = {
     var viewedMaterial = new THREE.MeshBasicMaterial({shading: THREE.FlatShading, color: 0x00f0ff})
     var materials = [ environment.defaultMaterial, viewedMaterial ]
 
-    for ( var i = 0; i < dreams.length; i ++ ) {
-
-      if (i % 4 === 1) { dreams[i].viewed = true} // test, delete later
+    dreams.forEach(function ( dream, i ) {
 
       var color = new THREE.Color();
       var quaternion = new THREE.Quaternion();
       var matrix = new THREE.Matrix4();
 
-      var singleDreamGeom = geometryChooser(dreams[i].sentiment)
+      var singleDreamGeom = geometryChooser(dream.sentiment)
 
       var matrixData = getMatrixData(i)
 
@@ -87,7 +85,7 @@ var dreamsView = {
 
 
       for (var j = facesLow; j <= facesHi; j++) {
-        allDreamsGeometry.faces[j].materialIndex = (dreams[i].viewed) ? 1 : 0
+        allDreamsGeometry.faces[j].materialIndex = (dream.viewed) ? 1 : 0
       };
 
       // give the singleDreamGeom's vertices a color corresponding to the "id"
@@ -101,13 +99,10 @@ var dreamsView = {
         scale: matrixData.scale,
         facesLocation: facesLocation
       }
-
-    }
-
+    })
 
     environment.allDreamsGeometry = allDreamsGeometry
     // allDreamsMesh is all of the dream objects merged together together
-    // environment.dreamsMesh = new THREE.Mesh( allDreamsGeometry, new THREE.MeshFaceMaterial() );
     environment.dreamsMesh = new THREE.Mesh( allDreamsGeometry, new THREE.MultiMaterial(materials) );
     environment.addObjectToScene( environment.dreamsMesh );
 

--- a/js/app/view.js
+++ b/js/app/view.js
@@ -58,7 +58,7 @@ var dreamsView = {
 
     for ( var i = 0; i < dreams.length; i ++ ) {
 
-      if (i % 2 === 0) { dreams[i].viewed = true} // test, delete later
+      if (i % 4 === 1) { dreams[i].viewed = true} // test, delete later
 
       var color = new THREE.Color();
       var quaternion = new THREE.Quaternion();
@@ -82,7 +82,13 @@ var dreamsView = {
         hi: facesAfterMerge - 1
       }
 
-      todo: if this dream has been viewed by the user already (as shown by the database dream.viewed attribute that is yet to be created), take these facesLocations, and itterate through the geometry
+      var facesLow = facesLocation.low
+      var facesHi = facesLocation.hi
+
+
+      for (var j = facesLow; j <= facesHi; j++) {
+        allDreamsGeometry.faces[j].materialIndex = (dreams[i].viewed) ? 1 : 0
+      };
 
       // give the singleDreamGeom's vertices a color corresponding to the "id"
       applyVertexColorsToGeometry( singleDreamGeom, color.setHex( i ) );
@@ -98,9 +104,6 @@ var dreamsView = {
 
     }
 
-    allDreamsGeometry.faces.forEach( function (face) {
-      face.materialIndex = 0
-    })
 
     environment.allDreamsGeometry = allDreamsGeometry
     // allDreamsMesh is all of the dream objects merged together together

--- a/js/app/view.js
+++ b/js/app/view.js
@@ -53,11 +53,13 @@ var dreamsView = {
     allDreamsGeometry = new THREE.Geometry()
     pickingGeometry = new THREE.Geometry()
 
-    var seenMaterial = new THREE.MeshBasicMaterial({shading: THREE.FlatShading, color: 0x00f0ff})
-    var materials = [ environment.defaultMaterial, seenMaterial ]
-    allDreamsGeometry.materials = materials
+    var viewedMaterial = new THREE.MeshBasicMaterial({shading: THREE.FlatShading, color: 0x00f0ff})
+    var materials = [ environment.defaultMaterial, viewedMaterial ]
 
     for ( var i = 0; i < dreams.length; i ++ ) {
+
+      if (i % 2 === 0) { dreams[i].viewed = true} // test, delete later
+
       var color = new THREE.Color();
       var quaternion = new THREE.Quaternion();
       var matrix = new THREE.Matrix4();
@@ -71,38 +73,18 @@ var dreamsView = {
       // the matrix has the position, scale, and rotation of the object
       matrix.compose( matrixData.position, quaternion, matrixData.scale );
 
-
       var facesBeforeMerge = allDreamsGeometry.faces.length
       allDreamsGeometry.merge(singleDreamGeom, matrix)
       var facesAfterMerge = allDreamsGeometry.faces.length
 
-      var facesLocation = {
+      var facesLocation = { // this is how we can find the faces for this particular geom, after it is merged into the single geom
         low: facesBeforeMerge,
         hi: facesAfterMerge - 1
       }
-      var low = facesLocation.low
-      var hi = facesLocation.hi
 
-      // console.log(hi)
-
-      // for (var j = low; j < hi; j++) {
-      //   // console.log(allDreamsGeometry.faces[j])
-      //   allDreamsGeometry.faces[ i ].materialIndex = 0
-      // };
-
-      // console.log(allDreamsGeometry)
-
-
-
-
-      // merge each geometry into the one 'master' geometry
-
-      // allDreamsGeometry.merge( singleDreamGeom, matrix );
-
-
+      todo: if this dream has been viewed by the user already (as shown by the database dream.viewed attribute that is yet to be created), take these facesLocations, and itterate through the geometry
 
       // give the singleDreamGeom's vertices a color corresponding to the "id"
-
       applyVertexColorsToGeometry( singleDreamGeom, color.setHex( i ) );
 
       pickingGeometry.merge( singleDreamGeom, matrix );

--- a/js/app/view.js
+++ b/js/app/view.js
@@ -53,9 +53,6 @@ var dreamsView = {
     allDreamsGeometry = new THREE.Geometry()
     pickingGeometry = new THREE.Geometry()
 
-    var viewedMaterial = new THREE.MeshBasicMaterial({shading: THREE.FlatShading, color: 0x00f0ff})
-    var materials = [ environment.defaultMaterial, viewedMaterial ]
-
     dreams.forEach(function ( dream, i ) {
 
       var color = new THREE.Color();
@@ -84,7 +81,7 @@ var dreamsView = {
       var facesHi = facesLocation.hi
 
 
-      for (var j = facesLow; j <= facesHi; j++) {
+      for (var j = facesLow; j <= facesHi; j++) { // this is to support dream.viewed feature yet to be added to the rails back end
         allDreamsGeometry.faces[j].materialIndex = (dream.viewed) ? 1 : 0
       };
 
@@ -103,6 +100,7 @@ var dreamsView = {
 
     environment.allDreamsGeometry = allDreamsGeometry
     // allDreamsMesh is all of the dream objects merged together together
+    var materials = [ environment.defaultMaterial, environment.viewedMaterial ]
     environment.dreamsMesh = new THREE.Mesh( allDreamsGeometry, new THREE.MultiMaterial(materials) );
     environment.addObjectToScene( environment.dreamsMesh );
 

--- a/js/app/view.js
+++ b/js/app/view.js
@@ -53,6 +53,10 @@ var dreamsView = {
     allDreamsGeometry = new THREE.Geometry()
     pickingGeometry = new THREE.Geometry()
 
+    var seenMaterial = new THREE.MeshBasicMaterial({shading: THREE.FlatShading, color: 0x00f0ff})
+    var materials = [ environment.defaultMaterial, seenMaterial ]
+    allDreamsGeometry.materials = materials
+
     for ( var i = 0; i < dreams.length; i ++ ) {
       var color = new THREE.Color();
       var quaternion = new THREE.Quaternion();
@@ -67,8 +71,35 @@ var dreamsView = {
       // the matrix has the position, scale, and rotation of the object
       matrix.compose( matrixData.position, quaternion, matrixData.scale );
 
+
+      var facesBeforeMerge = allDreamsGeometry.faces.length
+      allDreamsGeometry.merge(singleDreamGeom, matrix)
+      var facesAfterMerge = allDreamsGeometry.faces.length
+
+      var facesLocation = {
+        low: facesBeforeMerge,
+        hi: facesAfterMerge - 1
+      }
+      var low = facesLocation.low
+      var hi = facesLocation.hi
+
+      // console.log(hi)
+
+      // for (var j = low; j < hi; j++) {
+      //   // console.log(allDreamsGeometry.faces[j])
+      //   allDreamsGeometry.faces[ i ].materialIndex = 0
+      // };
+
+      // console.log(allDreamsGeometry)
+
+
+
+
       // merge each geometry into the one 'master' geometry
-      allDreamsGeometry.merge( singleDreamGeom, matrix );
+
+      // allDreamsGeometry.merge( singleDreamGeom, matrix );
+
+
 
       // give the singleDreamGeom's vertices a color corresponding to the "id"
 
@@ -79,14 +110,20 @@ var dreamsView = {
       environment.pickingData[ i ] = {
         position: matrixData.position,
         rotation: matrixData.rotation,
-        scale: matrixData.scale
+        scale: matrixData.scale,
+        facesLocation: facesLocation
       }
 
     }
 
+    allDreamsGeometry.faces.forEach( function (face) {
+      face.materialIndex = 0
+    })
 
+    environment.allDreamsGeometry = allDreamsGeometry
     // allDreamsMesh is all of the dream objects merged together together
-    environment.dreamsMesh = new THREE.Mesh( allDreamsGeometry, environment.defaultMaterial );
+    // environment.dreamsMesh = new THREE.Mesh( allDreamsGeometry, new THREE.MeshFaceMaterial() );
+    environment.dreamsMesh = new THREE.Mesh( allDreamsGeometry, new THREE.MultiMaterial(materials) );
     environment.addObjectToScene( environment.dreamsMesh );
 
     environment.pickingMesh = new THREE.Mesh( pickingGeometry, environment.pickingMaterial )

--- a/js/app/view.js
+++ b/js/app/view.js
@@ -1,13 +1,11 @@
 var Auth = global.Auth
 var environment = global.environment
 var THREE = require('three')
-var geometryChooser = require('./../services/geometry-chooser')
-var getMatrixData = require('./../services/get-matrix-data')
 var moment = require('moment')
 var parseDreamString = require('./../services/parse-dream-string')
 var $ = require('jquery')
 require('bootstrap-jquery')
-var range = require('lodash.range')
+var generateMergedGeometriesFromDreams = require('./../services/generate-merged-geometries-from-dreams')
 
 // posts stuff to the dom
 var dreamsView = {
@@ -50,61 +48,19 @@ var dreamsView = {
 
   // takes dreams, decides where they're going to go
   populateDreamscape: function (dreams) {
+    var mergedGeometries = generateMergedGeometriesFromDreams(dreams)
 
-    allDreamsGeometry = new THREE.Geometry()
-    pickingGeometry = new THREE.Geometry()
-
-    dreams.forEach(function ( dream, i ) {
-
-      var color = new THREE.Color();
-      var quaternion = new THREE.Quaternion();
-      var matrix = new THREE.Matrix4();
-
-      var singleDreamGeom = geometryChooser(dream.sentiment)
-
-      var matrixData = getMatrixData(i)
-
-      quaternion.setFromEuler( matrixData.rotation, false );
-
-      // the matrix has the position, scale, and rotation of the object
-      matrix.compose( matrixData.position, quaternion, matrixData.scale );
-
-      var faceCountBeforeMerge = allDreamsGeometry.faces.length
-      allDreamsGeometry.merge(singleDreamGeom, matrix)
-      var faceCountAfterMerge = allDreamsGeometry.faces.length
-
-      var faceIndices = { // this is how we can find the faces for this particular geom, after it is merged into the single geom
-        low: faceCountBeforeMerge,
-        hi: faceCountAfterMerge
-      }
-
-      range(faceIndices.low, faceIndices.hi).forEach(function (faceIndex) { // this is to support dream.viewed feature yet to be added to the rails back end
-        allDreamsGeometry.faces[faceIndex].materialIndex = (dream.viewed) ? 1 : 0
-      })
-
-      // give the singleDreamGeom's vertices a color corresponding to the "id"
-      applyVertexColorsToGeometry( singleDreamGeom, color.setHex( i ) );
-
-      pickingGeometry.merge( singleDreamGeom, matrix );
-
-      environment.pickingData[ i ] = {
-        position: matrixData.position,
-        rotation: matrixData.rotation,
-        scale: matrixData.scale,
-        faceIndices: faceIndices
-      }
-    })
+    environment.pickingData = mergedGeometries.pickingData
 
     // allDreamsMesh is all of the dream objects merged together together
     var materials = [ environment.defaultMaterial, environment.viewedMaterial ]
-    environment.dreamsMesh = new THREE.Mesh( allDreamsGeometry, new THREE.MultiMaterial(materials) );
+    environment.dreamsMesh = new THREE.Mesh( mergedGeometries.allDreamsGeometry, new THREE.MultiMaterial(materials) );
     environment.addObjectToScene( environment.dreamsMesh );
 
-    environment.pickingMesh = new THREE.Mesh( pickingGeometry, environment.pickingMaterial )
+    environment.pickingMesh = new THREE.Mesh( mergedGeometries.pickingGeometry, environment.pickingMaterial )
     environment.pickingScene.add( environment.pickingMesh );
 
     environment.resetCameraPosition()
-
   },
 
   showInfoModal: function () {
@@ -159,15 +115,6 @@ function parseTagObjects (tagObjects) {
     tags.push(tagObjects[i].word)
   }
   return tags
-}
-
-function applyVertexColorsToGeometry (geometry, color) {
-  geometry.faces.forEach(function (face) {
-    var n = (face instanceof THREE.Face3) ? 3 : 4;
-    for (var j = 0; j < n; j++) {
-      face.vertexColors[j] = color;
-    }
-  })
 }
 
 module.exports = dreamsView

--- a/js/app/view.js
+++ b/js/app/view.js
@@ -98,7 +98,6 @@ var dreamsView = {
       }
     })
 
-    environment.allDreamsGeometry = allDreamsGeometry
     // allDreamsMesh is all of the dream objects merged together together
     var materials = [ environment.defaultMaterial, environment.viewedMaterial ]
     environment.dreamsMesh = new THREE.Mesh( allDreamsGeometry, new THREE.MultiMaterial(materials) );

--- a/js/services/apply-vertex-colors-to-geometry.js
+++ b/js/services/apply-vertex-colors-to-geometry.js
@@ -1,0 +1,10 @@
+var THREE = require('three')
+
+module.exports = function (geometry, color) {
+  geometry.faces.forEach(function (face) {
+    var n = (face instanceof THREE.Face3) ? 3 : 4;
+    for (var j = 0; j < n; j++) {
+      face.vertexColors[j] = color;
+    }
+  })
+}

--- a/js/services/generate-merged-geometries-from-dreams.js
+++ b/js/services/generate-merged-geometries-from-dreams.js
@@ -9,8 +9,8 @@ module.exports = function (dreams) {
   var pickingGeometry = new THREE.Geometry()
   var pickingData = []
 
-  dreams.forEach(function ( dream, i ) {
-    var matrixData = getMatrixData(i)
+  dreams.forEach(function ( dream ) {
+    var matrixData = getMatrixData(dream.objectId)
     var singleDreamGeom = geometryChooser(dream.sentiment)
     var quaternion = new THREE.Quaternion()
     quaternion.setFromEuler( matrixData.rotation, false );
@@ -30,7 +30,7 @@ module.exports = function (dreams) {
 
     // give the singleDreamGeom's vertices a color corresponding to the "id"
     var color = new THREE.Color()
-    applyVertexColorsToGeometry( singleDreamGeom, color.setHex( i ) )
+    applyVertexColorsToGeometry( singleDreamGeom, color.setHex( dream.objectId ) )
 
     pickingGeometry.merge( singleDreamGeom, matrix )
 

--- a/js/services/generate-merged-geometries-from-dreams.js
+++ b/js/services/generate-merged-geometries-from-dreams.js
@@ -1,0 +1,50 @@
+var THREE = require('three')
+var getMatrixData = require('./get-matrix-data')
+var geometryChooser = require('./../services/geometry-chooser')
+var range = require('lodash.range')
+var applyVertexColorsToGeometry = require('./../services/apply-vertex-colors-to-geometry')
+
+module.exports = function (dreams) {
+  var allDreamsGeometry = new THREE.Geometry()
+  var pickingGeometry = new THREE.Geometry()
+  var pickingData = []
+
+  dreams.forEach(function ( dream, i ) {
+    var matrixData = getMatrixData(i)
+    var singleDreamGeom = geometryChooser(dream.sentiment)
+    var quaternion = new THREE.Quaternion()
+    quaternion.setFromEuler( matrixData.rotation, false );
+    var matrix = new THREE.Matrix4()
+    matrix.compose( matrixData.position, quaternion, matrixData.scale );
+
+    // this is how we can find the faces for this particular geom, after it is merged into the single geom
+    var faceCountBeforeMerge = allDreamsGeometry.faces.length
+    allDreamsGeometry.merge(singleDreamGeom, matrix)
+    var faceIndices = {
+      low: faceCountBeforeMerge,
+      hi: faceCountBeforeMerge + singleDreamGeom.faces.length
+    }
+    range(faceIndices.low, faceIndices.hi).forEach(function (faceIndex) { // this is to support dream.viewed feature yet to be added to the rails back end
+      allDreamsGeometry.faces[faceIndex].materialIndex = (dream.viewed) ? 1 : 0
+    })
+
+    // give the singleDreamGeom's vertices a color corresponding to the "id"
+    var color = new THREE.Color()
+    applyVertexColorsToGeometry( singleDreamGeom, color.setHex( i ) )
+
+    pickingGeometry.merge( singleDreamGeom, matrix )
+
+    pickingData.push({
+      position: matrixData.position,
+      rotation: matrixData.rotation,
+      scale: matrixData.scale,
+      faceIndices: faceIndices
+    })
+  })
+
+  return {
+    allDreamsGeometry: allDreamsGeometry,
+    pickingGeometry: pickingGeometry,
+    pickingData
+  }
+}

--- a/js/services/generate-merged-geometries-from-dreams.js
+++ b/js/services/generate-merged-geometries-from-dreams.js
@@ -45,6 +45,6 @@ module.exports = function (dreams) {
   return {
     allDreamsGeometry: allDreamsGeometry,
     pickingGeometry: pickingGeometry,
-    pickingData
+    pickingData: pickingData
   }
 }


### PR DESCRIPTION
Implementation of dreams changing color after being viewed. Currently this works until the user refreshes the page, then the dreams are back to all using the default texture.

The view is set up to respond to dream.viewed? boolean from the API, which will result in all viewed dreams rendering with the viewed material.

Improvements:
Implement dream.viewed? field in the Dream model in the API
Make the front end update the database for a user when they have viewed a dream.
Choose a viewed material that works stylistically.
