### PR TITLE
fetch dreams after fetching views, whether user is logged in or not

### DIFF
--- a/js/app/model.js
+++ b/js/app/model.js
@@ -28,7 +28,7 @@ var dreamsModel =  {
   getDreams: function (fetchType) {
     var self = this
     this.fetchDreams(fetchType).then(function () {
-      self.fetchViews().then(function () {
+      self.fetchViews().always(function () {
         environment.clearScene()
         dreamsView.populateDreamscape(self.dreamData)
       })


### PR DESCRIPTION
hotfix for https://github.com/enspiral-cherubi/dREAM-cACHER_interface_1.0/issues/25

before, i was fetching dreams only after successfully fetching views. but fetching views is only successful, if a user is signed in. silly mistake of mine 

in this PR, i've made it so that dreams are fetched regardless of whether the user is signed in

@will-sklenars  this is a quick one-line fix, so will merge now 
