### PR TITLE
remove redundant autoForward false, set dragToLook true

### DIFF
--- a/js/app/environment.js
+++ b/js/app/environment.js
@@ -23,10 +23,9 @@ var environment = {
 
 environment.initializeFlyControls = function () {
   this.controls = new THREE.FlyControls(this.camera, this.container)
-  this.controls.movementSpeed = 1;
-  this.controls.rollSpeed = Math.PI / 1600;
-  this.controls.autoForward = false;
-  this.controls.dragToLook = false;
+  this.controls.movementSpeed = 1
+  this.controls.rollSpeed = Math.PI / 1600
+  this.controls.dragToLook = true
 }
 
 environment.initializeRenderer = function () {


### PR DESCRIPTION
addresses https://github.com/enspiral-cherubi/dREAM-cACHER_interface_1.0/issues/9 and https://github.com/enspiral-cherubi/dREAM-cACHER_interface_1.0/issues/19

wow turns out that setting an instance of `THREE.FlyControls`' `dragToLook` property to `true` makes it so that the mouse only re-orients the camera on mousedown.

i figure this resolves the issues above

@will-sklenars 
