### PR TITLE
set html body as container

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <link href="./stylesheets/index.css" rel="stylesheet" />
 </head>
 
-<body>
+<body id="container">
   <!-- navbar -->
   <nav class="navbar navbar-default navbar-inverse" role="navigation">
     <div class="container-fluid">
@@ -139,8 +139,6 @@
       </div>
     </div>
   </div>
-
-  <div id="container"></div>
 
   <script src="./bundle.js"></script>
 </body>


### PR DESCRIPTION
sweet, by setting the environment's container on the `<body>` instead of a `<div>` in the `<body>`, we retain autofocus permanently

fixes https://github.com/enspiral-cherubi/dREAM-cACHER_interface_1.0/issues/21 - ready to merge if approved

@will-sklenars 
