### PR TITLE
set environment variables properly

### DIFF
--- a/js/config/api-url.js
+++ b/js/config/api-url.js
@@ -1,9 +1,12 @@
-var apiUrl;
+var apiUrl
 
-if (process.env.NODE_ENV === 'production') {
-  apiUrl = 'http://104.236.175.6'
-} else {
-  apiUrl = 'http://localhost:3000'
+switch (process.env.NODE_ENV) {
+  case 'production':
+    apiUrl = 'http://104.236.175.6'
+    break
+  case 'development':
+    apiUrl = 'http://localhost:3000'
+    break
 }
 
 module.exports = apiUrl

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This is the first iteration of the interface for the 'dREAM-cACHER' web application",
   "main": "./js/index.js",
   "scripts": {
-    "start": "budo . -d --serve bundle.js --live",
+    "start": "(export NODE_ENV=development; budo . -d --serve bundle.js --live)",
     "build": "browserify . -o bundle.js -g uglifyify",
     "test": "browserify test.js | smokestack | tap-spec",
     "dist": "mkdir -p dist && bash -c 'cp *.{js,html,css} dist'",
@@ -12,7 +12,9 @@
     "deploy": "(export NODE_ENV=production; git push origin master:gh-pages)"
   },
   "browserify": {
-    "transform": []
+    "transform": [
+      "envify"
+    ]
   },
   "repository": {
     "type": "git",
@@ -43,6 +45,7 @@
   "devDependencies": {
     "browserify": "^10.0.0",
     "budo": "^4.0.0",
+    "envify": "^3.4.0",
     "gh-pages": "^0.3.0",
     "smokestack": "^3.3.0",
     "tap-spec": "^4.0.2",


### PR DESCRIPTION
@will-sklenars 

installed / using [envify](https://github.com/hughsk/envify) to transform our references to environment variables like `apiUrl` in `js/config/api-url.js` to their actual values (set in the `start` and `deploy` scripts in our `package.json`), before browserify bundles everything

i'll merge immediately since you said you want to deploy soon
